### PR TITLE
fix: resolve connection leak causing 'Too many open files' error

### DIFF
--- a/src/api/download_routes.py
+++ b/src/api/download_routes.py
@@ -4,9 +4,11 @@ Download API routes for OpenSubtitles scraper service
 
 import logging
 import base64
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
-from ..core.scraper import OpenSubtitlesScraper
+
+# Import the shared scraper getter from routes
+from .routes import get_scraper
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,8 @@ async def download_subtitle(request: DownloadRequest):
     try:
         logger.info(f"Downloading subtitle from: {request.download_url}")
         
-        scraper = OpenSubtitlesScraper()
+        # Use shared scraper instance instead of creating new one
+        scraper = get_scraper()
         
         # Download the subtitle content
         content, filename = scraper.download_subtitle(request.download_url)

--- a/src/core/scraper.py
+++ b/src/core/scraper.py
@@ -22,7 +22,8 @@ class OpenSubtitlesScraper:
     def __init__(self, timeout: int = 30):
         self.session_manager = SessionManager(timeout=timeout)
         self.search_parser = SearchParser()
-        self.subtitle_parser = SubtitleParser()
+        # Pass session manager to subtitle parser to avoid creating new sessions
+        self.subtitle_parser = SubtitleParser(session_manager=self.session_manager)
         self.download_parser = DownloadParser()
         self.imdb_lookup = IMDBLookupService(self.session_manager)
         self.base_url = "https://www.opensubtitles.org"

--- a/src/core/session_manager.py
+++ b/src/core/session_manager.py
@@ -2,13 +2,22 @@
 
 import logging
 import time
+import threading
 from typing import Optional, Dict, Any
 import cloudscraper
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from requests.exceptions import RequestException, Timeout, ConnectionError
 
 from ..utils.exceptions import CloudflareError, ScrapingError, ServiceUnavailableError
 
 logger = logging.getLogger(__name__)
+
+
+# Connection pool limits to prevent "Too many open files" error
+MAX_POOL_CONNECTIONS = 10  # Maximum number of connection pools to cache
+MAX_POOL_SIZE = 5  # Maximum number of connections per pool
+MAX_RETRIES = 3  # Maximum retries for failed requests
 
 
 class SessionManager:
@@ -20,9 +29,12 @@ class SessionManager:
         self.base_url = "https://www.opensubtitles.org"
         self.last_request_time = 0
         self.min_request_interval = 1.0  # Minimum seconds between requests
+        self.request_count = 0
+        self.max_requests_before_cleanup = 50  # Cleanup connections after this many requests
+        self._lock = threading.Lock()  # Thread safety for session access
         
     def _create_session(self) -> cloudscraper.CloudScraper:
-        """Create a new cloudscraper session"""
+        """Create a new cloudscraper session with connection pool limits"""
         try:
             # Create cloudscraper with more robust configuration
             session = cloudscraper.create_scraper(
@@ -34,6 +46,26 @@ class SessionManager:
                 delay=10,
                 debug=False
             )
+            
+            # Configure retry strategy
+            retry_strategy = Retry(
+                total=MAX_RETRIES,
+                backoff_factor=1,
+                status_forcelist=[429, 500, 502, 503, 504],
+                allowed_methods=["HEAD", "GET", "OPTIONS"]
+            )
+            
+            # Configure HTTP adapter with connection pool limits
+            adapter = HTTPAdapter(
+                pool_connections=MAX_POOL_CONNECTIONS,
+                pool_maxsize=MAX_POOL_SIZE,
+                max_retries=retry_strategy,
+                pool_block=False  # Don't block when pool is full, create new connection
+            )
+            
+            # Mount adapter for both HTTP and HTTPS
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
             
             # Configure session for better compatibility
             session.verify = True  # Enable SSL verification
@@ -54,6 +86,7 @@ class SessionManager:
                 'Cache-Control': 'max-age=0',
             })
             
+            logger.info(f"Created cloudscraper session with pool_connections={MAX_POOL_CONNECTIONS}, pool_maxsize={MAX_POOL_SIZE}")
             return session
             
         except Exception as e:
@@ -61,12 +94,14 @@ class SessionManager:
             raise CloudflareError(f"Could not create session: {e}")
     
     def get_session(self) -> cloudscraper.CloudScraper:
-        """Get or create a cloudscraper session"""
-        if self.session is None:
-            self.session = self._create_session()
-            logger.info("Created new cloudscraper session")
-        
-        return self.session
+        """Get or create a cloudscraper session (thread-safe)"""
+        with self._lock:
+            if self.session is None:
+                self.session = self._create_session()
+                self.request_count = 0
+                logger.info("Created new cloudscraper session")
+            
+            return self.session
     
     def _wait_for_rate_limit(self):
         """Wait if necessary to respect rate limiting"""
@@ -79,6 +114,28 @@ class SessionManager:
             time.sleep(sleep_time)
         
         self.last_request_time = time.time()
+    
+    def _maybe_cleanup_connections(self):
+        """Periodically cleanup idle connections to prevent resource leaks"""
+        self.request_count += 1
+        
+        if self.request_count >= self.max_requests_before_cleanup:
+            logger.info(f"Cleaning up connections after {self.request_count} requests")
+            self._cleanup_idle_connections()
+            self.request_count = 0
+    
+    def _cleanup_idle_connections(self):
+        """Close idle connections in the pool"""
+        with self._lock:
+            if self.session:
+                try:
+                    # Get all adapters and close their connection pools
+                    for adapter in self.session.adapters.values():
+                        if hasattr(adapter, 'poolmanager') and adapter.poolmanager:
+                            adapter.poolmanager.clear()
+                    logger.debug("Cleared idle connection pools")
+                except Exception as e:
+                    logger.warning(f"Error cleaning up connections: {e}")
     
     def make_request(self, method: str, url: str, **kwargs) -> cloudscraper.requests.Response:
         """Make a request using cloudscraper with error handling"""
@@ -94,10 +151,13 @@ class SessionManager:
             logger.debug(f"Making {method.upper()} request to: {url}")
             response = session.request(method, url, **kwargs)
             
+            # Periodic connection cleanup
+            self._maybe_cleanup_connections()
+            
             # Check for Cloudflare challenge
             if 'cf-ray' in response.headers and response.status_code in [403, 503]:
                 logger.warning("Cloudflare challenge detected, recreating session")
-                self.session = None
+                self.close()  # Properly close old session
                 session = self.get_session()
                 response = session.request(method, url, **kwargs)
             
@@ -138,11 +198,21 @@ class SessionManager:
         return self.make_request('POST', url, **kwargs)
     
     def close(self):
-        """Close the session"""
-        if self.session:
-            self.session.close()
-            self.session = None
-            logger.info("Closed cloudscraper session")
+        """Close the session and release all resources"""
+        with self._lock:
+            if self.session:
+                try:
+                    # Close all adapters to release connection pools
+                    for adapter in self.session.adapters.values():
+                        if hasattr(adapter, 'close'):
+                            adapter.close()
+                    self.session.close()
+                except Exception as e:
+                    logger.warning(f"Error closing session: {e}")
+                finally:
+                    self.session = None
+                    self.request_count = 0
+                    logger.info("Closed cloudscraper session and released resources")
     
     def __enter__(self):
         return self


### PR DESCRIPTION
## Problem
The opensubtitles-scraper service was throwing `OSError: [Errno 24] Too many open files` errors due to connection/resource leaks.

## Root Causes Identified
1. **download_routes.py**: Created a NEW `OpenSubtitlesScraper()` for every download request without closing it
2. **subtitle_parser.py**: Created new `SessionManager()` instances inside loops for each episode
3. **session_manager.py**: No connection pool limits, no periodic cleanup

## Changes Made

### download_routes.py
- Now uses shared scraper instance via `get_scraper()` instead of creating new ones

### subtitle_parser.py  
- Accepts and reuses session manager from the scraper
- Removed inline `with SessionManager()` blocks that were creating new sessions

### scraper.py
- Pass session manager to subtitle parser on initialization

### session_manager.py
- Added connection pool limits (`MAX_POOL_CONNECTIONS=10`, `MAX_POOL_SIZE=5`)
- Added `HTTPAdapter` with proper pool configuration and retry strategy
- Added periodic connection cleanup after every 50 requests
- Added thread-safe session access with locks
- Improved `close()` method to properly release all adapter resources

## Testing
After applying these changes, restart the service on 192.168.100.6 and monitor for the error.