### PR TITLE
feat: upgrade to Python 3.14 with JIT support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Python 3.13 slim as base image for cutting-edge features
-FROM python:3.13-slim
+# Use Python 3.14 slim as base image with JIT support
+FROM python:3.14-slim
 
 # Set working directory
 WORKDIR /app
@@ -8,6 +8,12 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     && rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
+# PYTHON_JIT=1 enables experimental JIT compiler (Python 3.13+)
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHON_JIT=1
 
 # Copy requirements file
 COPY requirements.txt .
@@ -21,6 +27,10 @@ COPY . .
 
 # Expose port 8000
 EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 # Run the application
 CMD ["python", "main.py"]


### PR DESCRIPTION
- Updated base image from python:3.13-slim to python:3.14-slim
- Added PYTHON_JIT=1 to enable experimental JIT compiler
- Added PYTHONDONTWRITEBYTECODE and PYTHONUNBUFFERED env vars
- Added health check endpoint for container orchestration