### PR TITLE
fix: filter by language and improve TV series detection

### DIFF
--- a/src/core/scraper.py
+++ b/src/core/scraper.py
@@ -340,6 +340,12 @@ class OpenSubtitlesScraper:
         try:
             logger.info(f"Getting subtitles from: {movie_url}")
             
+            # Modify URL to search for specific language to avoid pagination issues
+            if languages:
+                lang_code = languages[0].lower()
+                movie_url = movie_url.replace('sublanguageid-all', f'sublanguageid-{lang_code}')
+                logger.debug(f"Modified movie URL for language {lang_code}: {movie_url}")
+            
             # Make request to movie/show page
             response = self.session_manager.get(movie_url)
             
@@ -559,6 +565,12 @@ class OpenSubtitlesScraper:
                 if target_episode_url.startswith('/'):
                     target_episode_url = self.base_url + target_episode_url
                 
+                # Modify URL to search for specific language to avoid pagination issues
+                if languages:
+                    lang_code = languages[0].lower()
+                    target_episode_url = target_episode_url.replace('sublanguageid-all', f'sublanguageid-{lang_code}')
+                    logger.debug(f"Modified target URL for language {lang_code}: {target_episode_url}")
+
                 link_text = target_link.get_text(strip=True)
                 logger.info(f"Found target episode {episode}: {link_text} -> {target_episode_url}")
             else:
@@ -682,11 +694,11 @@ class OpenSubtitlesScraper:
                 last_part = url_parts[-1]  # e.g., "the-exchange-bank-of-tomorrow-nl"
                 if '-' in last_part:
                     language = last_part.split('-')[-1]
-                    if len(language) == 2:  # Valid language code
+                    if len(language) in [2, 3]:  # Valid language code (2 or 3 letter)
                         return language
             
             # Fallback: extract from URL path
-            lang_match = re.search(r'/([a-z]{2})/', url)
+            lang_match = re.search(r'/([a-z]{2,3})/', url)
             if lang_match:
                 return lang_match.group(1)
             

--- a/src/parsers/subtitle_parser.py
+++ b/src/parsers/subtitle_parser.py
@@ -382,10 +382,14 @@ class SubtitleParser:
             if season_headers:
                 return True
             
-            # Look for episode links with IMDB IDs
+            # Look for episode links with IMDB IDs - but ONLY if we also see season/episode markers
+            # This prevents movie search results from being misidentified as TV series
             episode_links = soup.find_all('a', href=re.compile(r'/imdbid-\d+'))
-            if len(episode_links) > 3:  # Multiple episodes
-                return True
+            if len(episode_links) > 3:
+                # Additional check: verify there's actual episode data (not just movie links)
+                page_text = soup.get_text()
+                if re.search(r'(S\d{1,2}E\d{1,2}|Episode \d+)', page_text, re.I):
+                    return True
             
             return False
             


### PR DESCRIPTION
## Problem
Non-English subtitles (e.g. Polish) were not being returned for popular movies/shows due to two issues:

1. **Pagination limit**: OpenSubtitles returns max 40 results per page with `sublanguageid-all`. For popular titles, English subtitles dominate the first page, pushing other languages to page 2+.
2. **False TV series detection**: The [_is_episode_list_page()](cci:1://file:///tmp/lavx-scraper/src/parsers/subtitle_parser.py:376:4-392:24) method incorrectly identified movie search results as TV series pages when they contained many `/imdbid-X` links (from related movie recommendations).

## Solution

### 1. Language-specific URL injection ([scraper.py](cci:7://file:///tmp/scraper.py:0:0-0:0))
When a language is requested (e.g. `pol`), replace `sublanguageid-all` with `sublanguageid-{lang}` in the request URL. This forces OpenSubtitles to return only that language, ensuring results appear on page 1.

Applied in:
- [get_subtitles()](cci:1://file:///tmp/lavx-scraper/src/api/routes.py:181:0-224:76) for movies
- [_get_episode_subtitles()](cci:1://file:///tmp/scraper.py:466:4-537:24) for TV shows

### 2. 3-letter language code support ([scraper.py](cci:7://file:///tmp/scraper.py:0:0-0:0))
Updated [_extract_language_from_url()](cci:1://file:///tmp/scraper.py:608:4-628:23) to accept 3-letter ISO 639-2 codes (e.g. `pol`) in addition to 2-letter codes.

### 3. Improved TV series detection ([subtitle_parser.py](cci:7://file:///tmp/lavx-scraper/src/parsers/subtitle_parser.py:0:0-0:0))
Added secondary validation to [_is_episode_list_page()](cci:1://file:///tmp/lavx-scraper/src/parsers/subtitle_parser.py:376:4-392:24): when many `/imdbid-X` links are found, also check for actual episode markers (S##E## or "Episode X") before classifying as TV series. This prevents movie pages with related movie links from being misidentified.

## Testing
Tested with Inception (IMDB 1375666) + Polish language:
- Before: 0-1 subtitles
- After: 21 subtitles