### PR TITLE
Soup matching failed when episode links has specific language instead of "all"

### DIFF
--- a/src/parsers/subtitle_parser.py
+++ b/src/parsers/subtitle_parser.py
@@ -353,7 +353,7 @@ class SubtitleParser:
             subtitles = []
             
             # Find all episode links
-            episode_links = soup.find_all('a', href=re.compile(r'/en/search/sublanguageid-all/imdbid-\d+'))
+            episode_links = soup.find_all('a', href=re.compile(r'/en/search/sublanguageid-\w+/imdbid-\d+'))
             
             logger.info(f"Found {len(episode_links)} episodes to process")
             


### PR DESCRIPTION
Episode links sometime has a specific language and not `all`, so soup matching failed.