### PR TITLE
Accept season and episode input from request

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -38,6 +38,8 @@ class SubtitleRequest(BaseModel):
     """Request model for subtitle listings"""
     movie_url: str = Field(..., description="Movie/show URL from search results")
     languages: Optional[List[str]] = Field(None, description="Language codes to filter")
+    season: Optional[int] = Field(None, description="Season number for TV episodes")
+    episode: Optional[int] = Field(None, description="Episode number for TV episodes")
 
     @field_validator("movie_url")
     @classmethod

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -268,7 +268,9 @@ def get_subtitles(request: SubtitleRequest, scraper: OpenSubtitlesScraper = Depe
             
             subtitles = scraper.get_subtitles(
                 movie_url=request.movie_url,
-                languages=request.languages
+                languages=request.languages,
+                season=request.season,
+                episode=request.episode,
             )
             
             subtitle_infos = [

--- a/tests/test_routes_and_models.py
+++ b/tests/test_routes_and_models.py
@@ -379,12 +379,16 @@ class TestSubtitles:
     def test_with_languages(self, client, mock_scraper):
         resp = client.post("/api/v1/subtitles", json={
             "movie_url": "https://www.opensubtitles.org/en/foo",
-            "languages": ["eng", "fre"]
+            "languages": ["eng", "fre"],
+            "season": 1,
+            "episode": 1,
         })
         assert resp.status_code == 200
         mock_scraper.get_subtitles.assert_called_once_with(
             movie_url="https://www.opensubtitles.org/en/foo",
-            languages=["eng", "fre"]
+            languages=["eng", "fre"],
+            season=1,
+            episode=1,
         )
 
     def test_bad_url_host(self, client):


### PR DESCRIPTION
Accept the parameters `season` and `episode` to better find the subtitles the client is looking for. Almost all of the functionality to find a specific episode was already here, but it wasn't used.