### PR TITLE
Clear anubis cookie cache when it's invalid

### DIFF
--- a/src/core/anubis_solver.py
+++ b/src/core/anubis_solver.py
@@ -157,6 +157,22 @@ def _save_cookies_to_cache(domain: str, cookies: dict) -> None:
         logger.debug("Could not save Anubis cookie cache: %s", e)
 
 
+def invalidate_cached_cookies(domain: str) -> None:
+    """Remove cached Anubis cookies for a domain (called when cached cookies are stale)."""
+    try:
+        if not os.path.exists(_COOKIE_CACHE_PATH):
+            return
+        with open(_COOKIE_CACHE_PATH, "r") as f:
+            cache = json.load(f)
+        if domain in cache:
+            del cache[domain]
+            with open(_COOKIE_CACHE_PATH, "w") as f:
+                json.dump(cache, f)
+            logger.debug("Invalidated Anubis cookie cache for %s", domain)
+    except Exception as e:
+        logger.debug("Could not invalidate Anubis cookie cache: %s", e)
+
+
 def solve_anubis_challenge(
     session: requests.Session,
     challenge_url: str,
@@ -300,3 +316,4 @@ def solve_anubis_challenge(
     except Exception as e:
         logger.error("Anubis solver failed: %s", e)
         return None
+

--- a/src/core/session_manager.py
+++ b/src/core/session_manager.py
@@ -257,31 +257,16 @@ class SessionManager:
         for cookie in self.session.cookies:
             anubis_session.cookies.set(cookie.name, cookie.value, domain=cookie.domain)
 
-        cookies = solve_anubis_challenge(
-            anubis_session, challenge_url, original_url, timeout=self.timeout,
-        )
-
-        if not cookies:
-            raise CloudflareError(
-                f"Anubis challenge at {challenge_url} could not be solved"
-            )
-
-        # Inject the Anubis cookies into our main session
         session = self.get_session()
-        for name, value in cookies.items():
-            session.cookies.set(name, value)
-            self.session.cookies.set(name, value)
-        logger.info("Injected %d Anubis cookies into session", len(cookies))
+        domain = urlparse(challenge_url).netloc
 
-        # Retry the original request with the new cookies
-        resp = session.request("GET", original_url, timeout=(10, min(self.timeout, 15)))
-        if is_anubis_challenge(resp.url, resp.status_code):
-            # Cached cookies were stale, invalidate and re-solve fresh
-            domain = urlparse(challenge_url).netloc
-            logger.warning(
-                "Cached Anubis cookies rejected by server for %s, re-solving fresh", domain
-            )
-            invalidate_cached_cookies(domain)
+        for attempt in range(2):
+            if attempt == 1:
+                logger.warning(
+                    "Cached Anubis cookies rejected by server for %s, re-solving fresh", domain
+                )
+                invalidate_cached_cookies(domain)
+
             cookies = solve_anubis_challenge(
                 anubis_session, challenge_url, original_url, timeout=self.timeout,
             )
@@ -289,18 +274,20 @@ class SessionManager:
                 raise CloudflareError(
                     f"Anubis challenge at {challenge_url} could not be solved"
                 )
+
             for name, value in cookies.items():
                 session.cookies.set(name, value)
                 self.session.cookies.set(name, value)
-            logger.info("Injected %d fresh Anubis cookies into session", len(cookies))
-            resp = session.request("GET", original_url, timeout=(10, min(self.timeout, 15)))
-            if is_anubis_challenge(resp.url, resp.status_code):
-                raise CloudflareError(
-                    f"Anubis challenge persists after fresh solve (redirected to {resp.url})"
-                )
+            logger.info("Injected %d Anubis cookies into session", len(cookies))
 
-        resp.raise_for_status()
-        return resp
+            resp = session.request("GET", original_url, timeout=(10, min(self.timeout, 15)))
+            if not is_anubis_challenge(resp.url, resp.status_code):
+                resp.raise_for_status()
+                return resp
+
+        raise CloudflareError(
+            f"Anubis challenge persists after fresh solve (redirected to {resp.url})"
+        )
 
     def _is_cloudflare_active(self, url: str) -> bool:
         """Quick pre-flight check: is Cloudflare blocking this URL?

--- a/src/core/session_manager.py
+++ b/src/core/session_manager.py
@@ -13,7 +13,7 @@ from requests.exceptions import RequestException, Timeout, ConnectionError
 
 from urllib.parse import urlparse as _urlparse
 
-from .anubis_solver import is_anubis_challenge, solve_anubis_challenge
+from .anubis_solver import is_anubis_challenge, invalidate_cached_cookies, solve_anubis_challenge
 
 from ..utils.exceptions import CloudflareError, ScrapingError, ServiceUnavailableError
 from ..utils.url_validator import validate_target_url
@@ -241,6 +241,7 @@ class SessionManager:
     def _solve_anubis(self, original_url: str, challenge_url: str):
         """Solve an Anubis PoW challenge and retry the original request."""
         import requests as plain_requests
+        from urllib.parse import urlparse
 
         # Use a plain requests session (not cloudscraper) for the Anubis flow
         anubis_session = plain_requests.Session()
@@ -275,9 +276,29 @@ class SessionManager:
         # Retry the original request with the new cookies
         resp = session.request("GET", original_url, timeout=(10, min(self.timeout, 15)))
         if is_anubis_challenge(resp.url, resp.status_code):
-            raise CloudflareError(
-                f"Anubis challenge persists after solving (redirected to {resp.url})"
+            # Cached cookies were stale, invalidate and re-solve fresh
+            domain = urlparse(challenge_url).netloc
+            logger.warning(
+                "Cached Anubis cookies rejected by server for %s, re-solving fresh", domain
             )
+            invalidate_cached_cookies(domain)
+            cookies = solve_anubis_challenge(
+                anubis_session, challenge_url, original_url, timeout=self.timeout,
+            )
+            if not cookies:
+                raise CloudflareError(
+                    f"Anubis challenge at {challenge_url} could not be solved"
+                )
+            for name, value in cookies.items():
+                session.cookies.set(name, value)
+                self.session.cookies.set(name, value)
+            logger.info("Injected %d fresh Anubis cookies into session", len(cookies))
+            resp = session.request("GET", original_url, timeout=(10, min(self.timeout, 15)))
+            if is_anubis_challenge(resp.url, resp.status_code):
+                raise CloudflareError(
+                    f"Anubis challenge persists after fresh solve (redirected to {resp.url})"
+                )
+
         resp.raise_for_status()
         return resp
 
@@ -609,3 +630,4 @@ class SessionManager:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+


### PR DESCRIPTION
If the Anubis cookies were invalid but hadn't expired, `_solve_anubis()` detected that but didn't do anything about it. This change clears the cache and tries again when that happens.

I'm not sure how I ended up in the state where the cookies were invalid but not expired, but to test this fix you can manually edit `/tmp/anubis_cookies.json` and change something in the `techaro.lol-anubis-auth` key.